### PR TITLE
Command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Register bank after halting:
 ╘═════╧═══╧═════╧══════════╛
 ```
 
-Passing `debug` as the second argument will enable the debugging mode, in which the values of the register bank will be dumped after executing every instruction:
+Using `-d` or `--debug` will enable the debugging mode, in which the values of the register bank will be dumped after executing every instruction:
 
 ```
-$ python run.py demos/function_call.s debug
+$ python run.py --debug demos/function_call.s
 Debug mode: True
 Executing mov r1, #1 from 0
 Register bank after executing the instruction:

--- a/run.py
+++ b/run.py
@@ -1,16 +1,16 @@
 from xsvm import vm, parser
-import sys
+from argparse import ArgumentParser
 
-if len(sys.argv) >= 3 and sys.argv[2] == "debug":
-    debug = True
-else:
-    debug = False
 
-print "Debug mode: {d}".format(d=debug)
+args = ArgumentParser()
+args.add_argument("filename")
+args.add_argument("-d", "--debug", action="store_true", default=False)
+args = args.parse_args()
 
-machine = vm.Processor(debug=debug)
-filename = sys.argv[1]
-parser.load_file_into_memory(machine.memory, filename)
+print "Debug mode: {d}".format(d=args.debug)
+
+machine = vm.Processor(debug=args.debug)
+parser.load_file_into_memory(machine.memory, args.filename)
 
 machine.execute_until_halted(instructions_limit=5000)
 

--- a/run.py
+++ b/run.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 args = ArgumentParser()
 args.add_argument("filename")
 args.add_argument("-d", "--debug", action="store_true", default=False)
+args.add_argument("-m", "--max-instructions", metavar='', type=int, default=5000)
 args = args.parse_args()
 
 print "Debug mode: {d}".format(d=args.debug)
@@ -12,7 +13,7 @@ print "Debug mode: {d}".format(d=args.debug)
 machine = vm.Processor(debug=args.debug)
 parser.load_file_into_memory(machine.memory, args.filename)
 
-machine.execute_until_halted(instructions_limit=5000)
+machine.execute_until_halted(instructions_limit=args.max_instructions)
 
 print "Instructions executed: {i}".format(i=machine.instructions_executed)
 print "Instructions executed by type:"


### PR DESCRIPTION
First things first, nice project :+1: 

I've switched out the argument handling code for the `argparse` module _(which is standard library btw)_. The debug mode can be switched on with `-d` or `--debug` and I added a flag for the instruction limit with `-m` or `--max-instructions`.
